### PR TITLE
Add dbtdoc-bucket-path annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ dbtdoc:
 
 *Limitation: all dbt docs must be saved on same backend type (GoogleStorage or S3)*
 
-Add `dbtdoc-bucket` as annotation in `catalog-info.yaml`:
+Add `dbtdoc-bucket` as annotation in `catalog-info.yaml`. Optionally, add the `dbtdoc-path` annotation if your GCS bucket structure does not conform to the expected structure.
 
 ```yaml
 apiVersion: backstage.io/v1alpha1
@@ -198,6 +198,7 @@ metadata:
   name: "test"
   annotations:
     dbtdoc-bucket: "my-bucket"
+    dbtdoc-path: "optional/override/path" # Optional
 ```
 
 Then you can add to your `app-config.yaml`:
@@ -211,12 +212,16 @@ dbtdoc:
 
 **Following path must be respect regardless your bucket setup (single or multi).**
 
+If using the multi setup, you can override the `{kind}/{name}` portion of the path using the `dbtdoc-path` annotation.
+
 You can upload your `manifest.json` and `catalog.json` to a GCS Bucket as follow:
 
 - `{dbtdoc-bucket}/{kind}/{name}/manifest.json`
 - `{dbtdoc-bucket}/{kind}/{name}/catalog.json`
 
-For authentication to GCS Bucket, the plugin use ADC credentials [https://cloud.google.com/docs/authentication/provide-credentials-adc](https://cloud.google.com/docs/authentication/provide-credentials-adc).
+### Authentication
+
+For authentification to GCS Bucket, the plugin use ADC credentials [https://cloud.google.com/docs/authentication/provide-credentials-adc](https://cloud.google.com/docs/authentication/provide-credentials-adc).
 
 ## Update from v1 to v2
 

--- a/packages/dbt-backend/src/service/router.ts
+++ b/packages/dbt-backend/src/service/router.ts
@@ -38,9 +38,10 @@ export async function createRouter(options: RouterOptions): Promise<express.Rout
 
   async function handleRequest(req: Request, res: Response, type: 'manifest' | 'catalog') {
     const { bucket, kind, name } = req.params;
+    const bucketPath = req.query.bucketPath;
     const backend = config.getString('dbtdoc.backend')
 
-    const filePath = `${kind}/${name}/${type}.json`;
+    const filePath = bucketPath ? `${bucketPath}/${type}.json` : `${kind}/${name}/${type}.json`;
     const fullPath = `${bucket}/${filePath}`;
 
     let storageProvider: StorageProvider;

--- a/packages/dbt/src/components/DbtComponent/DbtComponent.tsx
+++ b/packages/dbt/src/components/DbtComponent/DbtComponent.tsx
@@ -37,11 +37,19 @@ function getManifest(): { manifest: Manifest, manifest_loading: boolean, manifes
     };
     return { manifest, manifest_loading, manifest_error }
   }
+  let doc_bucket_path = "";
+  if (entity.metadata.annotations?.["dbtdoc-path"] != null) {
+    doc_bucket_path = entity.metadata.annotations?.["dbtdoc-path"].replace(/^\/|\/$/g, "");;
+  }
 
   const { value, loading, error } = useAsync(async (): Promise<Manifest> => {
-    const response = await fetch(
-      `${base_url}/api/dbt/manifest/${doc_bucket}/${entity.kind}/${entity.metadata.name}`
-    );
+    let url = `${base_url}/api/dbt/manifest/${doc_bucket}/${entity.kind}/${entity.metadata.name}`;
+
+    if (doc_bucket_path) {
+      const params = new URLSearchParams({ bucketPath: doc_bucket_path });
+      url = `${url}?${params.toString()}`;
+    }
+    const response = await fetch(url);
     const data = await response.json();
     return data;
   }, []);
@@ -78,11 +86,19 @@ function getCatalog(): { catalog: Catalog, catalog_loading: boolean, catalog_err
     };
     return { catalog, catalog_loading, catalog_error }
   }
+  let doc_bucket_path = "";
+  if (entity.metadata.annotations?.["dbtdoc-path"] != null) {
+    doc_bucket_path = entity.metadata.annotations?.["dbtdoc-path"].replace(/^\/|\/$/g, "");;
+  }
 
-  const { value, loading, error } = useAsync(async (): Promise<Catalog> => {
-    const response = await fetch(
-      `${base_url}/api/dbt/catalog/${doc_bucket}/${entity.kind}/${entity.metadata.name}`
-    );
+  const { value, loading, error } = useAsync(async (): Promise<Manifest> => {
+    let url = `${base_url}/api/dbt/catalog/${doc_bucket}/${entity.kind}/${entity.metadata.name}`;
+
+    if (doc_bucket_path) {
+      const params = new URLSearchParams({ bucketPath: doc_bucket_path });
+      url = `${url}?${params.toString()}`;
+    }
+    const response = await fetch(url);
     const data = await response.json();
     return data;
   }, []);


### PR DESCRIPTION
### Why

We want to use this plugin but the path to the DBT docs in our GCS bucket does not conform to the expected path. I have a feeling that other people will encounter this limitation, especially since the expected path uses `kind` which is a specific Backstage term.

### What

Adding an optional `dbtdoc-path` annotation that can be used in an entity's `catalog-info` file as part of the multi setup. This path will override the `{kind}/{name}` portion of the path.
